### PR TITLE
Set `reuseaddr` to `false`.

### DIFF
--- a/src/fake_turn.app.src
+++ b/src/fake_turn.app.src
@@ -25,7 +25,7 @@
  fake_turn,
  [{description,
    "TURN serving as an endpoint to Membrane RTC Engine. Forked from https://github.com/processone/stun"},
-  {vsn, "0.2.4"},
+  {vsn, "0.2.5"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, fast_tls, p1_utils]},

--- a/src/stun_listener.erl
+++ b/src/stun_listener.erl
@@ -131,7 +131,7 @@ start_listener(IP, ClientPort, {MinPort, MaxPort}, Transport, Opts, Owner)
                            {ip, IP},
                            {packet, 0},
                            {active, false},
-                           {reuseaddr, true},
+                           {reuseaddr, false},
                            {nodelay, true},
                            {keepalive, true},
                            {send_timeout, ?TCP_SEND_TIMEOUT},
@@ -166,7 +166,7 @@ start_listener(IP, ClientPort, {MinPort, MaxPort}, udp, Opts, Owner) ->
             {active, false},
             {recbuf, ?UDP_RECBUF},
             {read_packets, ?UDP_READ_PACKETS}, 
-            {reuseaddr, true}])
+            {reuseaddr, false}])
         end,
     PortInfo =
         if ClientPort == undefined ->


### PR DESCRIPTION
This (hopefully) fixes a bug where a port number could have been assigned twice and has absolutely no side-effects.