### PR TITLE
Don't use REUSEADDR for UDP sockets

### DIFF
--- a/src/fake_turn.app.src
+++ b/src/fake_turn.app.src
@@ -25,7 +25,7 @@
  fake_turn,
  [{description,
    "TURN serving as an endpoint to Membrane RTC Engine. Forked from https://github.com/processone/stun"},
-  {vsn, "0.4.2"},
+  {vsn, "0.4.3"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, fast_tls, p1_utils]},

--- a/src/stun_listener.erl
+++ b/src/stun_listener.erl
@@ -165,8 +165,7 @@ start_listener(IP, ClientPort, {MinPort, MaxPort}, udp, Opts, Owner) ->
             {ip, IP}, 
             {active, false},
             {recbuf, ?UDP_RECBUF},
-            {read_packets, ?UDP_READ_PACKETS}, 
-            {reuseaddr, true}])
+            {read_packets, ?UDP_READ_PACKETS}])
         end,
     PortInfo =
         if ClientPort == undefined ->


### PR DESCRIPTION
When using REUSEADDR, we can alaways open a socket even if the port is already taken. This can lead to a situation where we have two sockets open on the same port. This probably depends on the system but in our case the traffic is always routed to the last open socket, which, at the end of the day, leads to a situation where we try to authenticate user 1 with secret of user 2. 